### PR TITLE
Support oneOf OpenAPI type

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -67,6 +67,7 @@ public class CodegenProperty implements Cloneable {
     public CodegenProperty items;
     public CodegenProperty mostInnerItems;
     public List<Map<String, String>> oneOf;
+    public boolean isVariant;
     public Map<String, Object> vendorExtensions = new HashMap<String, Object>();
     public boolean hasValidation; // true if pattern, maximum, etc are set (only used in the mustache template)
     public boolean isInherited;
@@ -349,6 +350,7 @@ public class CodegenProperty implements Cloneable {
 
     public void setOneOf(List<Map<String, String>> oneOf) {
         this.oneOf = oneOf;
+        this.isVariant = ((oneOf != null) && !oneOf.isEmpty());
     }
 
     public Map<String, Object> getVendorExtensions() {
@@ -466,6 +468,7 @@ public class CodegenProperty implements Cloneable {
             setter,
             unescapedDescription,
             oneOf,
+            isVariant,
             vendorExtensions,
             hasValidation,
             isString,
@@ -550,6 +553,7 @@ public class CodegenProperty implements Cloneable {
             Objects.equals(_enum, other._enum) &&
             Objects.equals(allowableValues, other.allowableValues) &&
             Objects.equals(oneOf, other.oneOf) &&
+            Objects.equals(isVariant, other.isVariant) &&
             Objects.equals(vendorExtensions, other.vendorExtensions) &&
             Objects.equals(hasValidation, other.hasValidation) &&
             Objects.equals(isString, other.isString) &&
@@ -684,6 +688,7 @@ public class CodegenProperty implements Cloneable {
                 ", items=" + items +
                 ", mostInnerItems=" + mostInnerItems +
                 ", oneOf=" + oneOf +
+                ", isVariant=" + isVariant +
                 ", vendorExtensions=" + vendorExtensions +
                 ", hasValidation=" + hasValidation +
                 ", isInherited=" + isInherited +

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -66,6 +66,7 @@ public class CodegenProperty implements Cloneable {
     public Map<String, Object> allowableValues;
     public CodegenProperty items;
     public CodegenProperty mostInnerItems;
+    public List<Map<String, String>> oneOf;
     public Map<String, Object> vendorExtensions = new HashMap<String, Object>();
     public boolean hasValidation; // true if pattern, maximum, etc are set (only used in the mustache template)
     public boolean isInherited;
@@ -342,6 +343,14 @@ public class CodegenProperty implements Cloneable {
         this.items = items;
     }
 
+    public List<Map<String, String>> getOneOf() {
+        return oneOf;
+    }
+
+    public void setOneOf(List<Map<String, String>> oneOf) {
+        this.oneOf = oneOf;
+    }
+
     public Map<String, Object> getVendorExtensions() {
         return vendorExtensions;
     }
@@ -456,6 +465,7 @@ public class CodegenProperty implements Cloneable {
             secondaryParam,
             setter,
             unescapedDescription,
+            oneOf,
             vendorExtensions,
             hasValidation,
             isString,
@@ -539,6 +549,7 @@ public class CodegenProperty implements Cloneable {
             Objects.equals(isSelfReference, other.isSelfReference) &&
             Objects.equals(_enum, other._enum) &&
             Objects.equals(allowableValues, other.allowableValues) &&
+            Objects.equals(oneOf, other.oneOf) &&
             Objects.equals(vendorExtensions, other.vendorExtensions) &&
             Objects.equals(hasValidation, other.hasValidation) &&
             Objects.equals(isString, other.isString) &&
@@ -589,6 +600,13 @@ public class CodegenProperty implements Cloneable {
             }
             if (this.mostInnerItems != null) {
                 cp.mostInnerItems = this.mostInnerItems;
+            }
+            if (this.oneOf != null) {
+                cp.oneOf = new ArrayList<Map<String, String>>();
+                for (Map<String, String> e : this.oneOf) {
+                    Map<String, String> myE = new HashMap<String, String>(e);
+                    cp.oneOf.add(myE);
+                }
             }
             if (this.vendorExtensions != null) {
                 cp.vendorExtensions = new HashMap<String, Object>(this.vendorExtensions);
@@ -665,6 +683,7 @@ public class CodegenProperty implements Cloneable {
                 ", allowableValues=" + allowableValues +
                 ", items=" + items +
                 ", mostInnerItems=" + mostInnerItems +
+                ", oneOf=" + oneOf +
                 ", vendorExtensions=" + vendorExtensions +
                 ", hasValidation=" + hasValidation +
                 ", isInherited=" + isInherited +

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2319,6 +2319,21 @@ public class DefaultCodegen implements CodegenConfig {
             setNonArrayMapProperty(property, type);
             Schema refOrCurrent = ModelUtils.getReferencedSchema(this.openAPI, p);
             property.isModel = (ModelUtils.isComposedSchema(refOrCurrent) || ModelUtils.isObjectSchema(refOrCurrent)) && ModelUtils.isModel(refOrCurrent);
+
+            // This adds 'oneOf' properties to the codegen property so that the oneOf data is
+            // available from mustache.
+            if (ModelUtils.isComposedSchema(refOrCurrent)) {
+                ComposedSchema cs = (ComposedSchema)refOrCurrent;
+                if (cs.getOneOf() != null) {
+                    List<Map<String, String>> myOneOf = new ArrayList<Map<String, String>>();
+                    for (Schema s : cs.getOneOf()) {
+                        Map<String, String> myMap = new HashMap<String, String>();
+                        myMap.put("innerDataType", getSchemaType(s));
+                        myOneOf.add(myMap);
+                    }
+                    property.setOneOf(myOneOf);
+                }
+            }
         }
 
         LOGGER.debug("debugging from property return: " + property);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SCMuseClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SCMuseClientCodegen.java
@@ -193,8 +193,6 @@ public class SCMuseClientCodegen extends AbstractCppCodegen {
 
     @Override
     public CodegenModel fromModel(String name, Schema model) {
-        name = cleanModelName(name);
-
         CodegenModel codegenModel = super.fromModel(name, model);
         Set<String> oldImports = codegenModel.imports;
         codegenModel.imports = new HashSet<String>();
@@ -207,20 +205,9 @@ public class SCMuseClientCodegen extends AbstractCppCodegen {
         return codegenModel;
     }
 
-    private String cleanModelName(String name) {
-        // Some model names parsed to Namespace_ModelName, this removes the '_'.
-        String[] split = name.split("_");
-
-        String output = name;
-        if (split.length > 1) {
-            output = split[0] + split[1];
-        }
-        return output;
-    }
-
     @Override
     public String toModelFilename(String name) {
-        return toModelName(cleanModelName(name));
+        return toModelName(name);
     }
 
     @Override


### PR DESCRIPTION
Hack in support for the *oneOf* OpenAPI type. This is pretty raw, but it fixes a few problems.

1. It fixes the include name handling by removing the "clean up" function. Now the inline response header is handled correctly in SCLib.
2. It adds oneOf support to the SCLib language. The oneOf concept is mapped to boost::variant
3. Add a new code gen property that allows languages to reference the oneOf types from the template (mustache).