### PR TITLE
Fixs target formatting for template

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SCMuseClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SCMuseClientCodegen.java
@@ -272,10 +272,14 @@ public class SCMuseClientCodegen extends AbstractCppCodegen {
         String[] split = path.split("/");
 
         if (split.length >= 2 && targets.contains(split[1])) {
-            return split[1];
+            return toTitleCase(split[1].substring(0, split[1].length() - 1));
         }
 
-        return "none";
+        return null;
+    }
+
+    String toTitleCase(String s) {
+        return Character.toUpperCase(s.charAt(0)) + s.substring(1);
     }
 
     String toCamelCase(String s) {


### PR DESCRIPTION
Summary:

This change is used by https://github.com/Sonos-Inc/pdsw-muse-control-clients/tree/SWPBL-146965
to generate the correct target calls in the templates. I also return `null` instead of `"none"` as it is not
a valid target. The `null` allow us to skip code gen for target in the `none` case.