### PR TITLE
SWPBL-152915: History namespace class in SCMuseLib doesn't appear to be generated correctly

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SCMuseClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SCMuseClientCodegen.java
@@ -283,7 +283,6 @@ public class SCMuseClientCodegen extends AbstractCppCodegen {
 
     protected String getTargetFromParameter(String param) {
         if (param.endsWith("Id")) {
-            // Get possibleTarget namespace by stripping Id, and adding an 's'
             String possibleTarget = param.substring(0, param.lastIndexOf("Id"));
             if (targets.contains(possibleTarget)) {
                 // This parameter seems to be a target ID parameter, lets mark it...

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SCMuseClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SCMuseClientCodegen.java
@@ -98,10 +98,10 @@ public class SCMuseClientCodegen extends AbstractCppCodegen {
         importMapping.put("Object", "#include \"MuseObject.h\"");
 
         targets = new HashSet<String>();
-        targets.add("households");
-        targets.add("players");
-        targets.add("groups");
-        targets.add("sessions");
+        targets.add("household");
+        targets.add("player");
+        targets.add("group");
+        targets.add("session");
     }
 
     /**
@@ -284,7 +284,7 @@ public class SCMuseClientCodegen extends AbstractCppCodegen {
     protected String getTargetFromParameter(String param) {
         if (param.endsWith("Id")) {
             // Get possibleTarget namespace by stripping Id, and adding an 's'
-            String possibleTarget = param.substring(0, param.lastIndexOf("Id")).concat("s");
+            String possibleTarget = param.substring(0, param.lastIndexOf("Id"));
             if (targets.contains(possibleTarget)) {
                 // This parameter seems to be a target ID parameter, lets mark it...
                 return possibleTarget;


### PR DESCRIPTION
## Summary

The Open API spec defines parameters as path, header, body, cookie, etc.
Previously, the MuseLib generator and templates only supported body parameters.
This change accommodate the templates by introducing the `x-muse-target-parameter` 
vendor extension and others.

## Verification

- Using this version of the generator, generated and built MuseLib and linked to the
iCR.  


